### PR TITLE
Create and Bind Cloudant Service Within Bluemix

### DIFF
--- a/.cfignore
+++ b/.cfignore
@@ -1,1 +1,1 @@
-node_modules
+/node_modules

--- a/.cfignore
+++ b/.cfignore
@@ -1,1 +1,2 @@
+/.env
 /node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-node_modules
+/node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+/.env
 /node_modules

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: node app.js

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ Get the project and install its dependencies:
 
 ## Running
 
-Run the project through npm:
+Run the project through [Foreman](https://github.com/ddollar/foreman):
 
-    $ npm start
+    $ foreman start
 
 ## Deploying
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,18 @@ Once you have completed the above steps, simply:
 
     $ cf push
 
+## Configuring
+
+### Development
+
+Local configuration is done through a `.env` file. One environment variable, `VCAP_SERVICES`, is needed in order to configure your local development environment. The value of the `VCAP_SERVICES` is a string representation of a JSON object. Here is an example `.env` file:
+
+    VCAP_SERVICES={"cloudantNoSQLDB": [{"name": "cloudant-location-tracker-db","label": "cloudantNoSQLDB","plan": "Shared","credentials": {"username": "your-username","password": "your-password","host": "your-host","port": 443,"url": "https://your-username:your-password@your-host"}}]}
+
+### Production
+
+Services created within Bluemix are automatically added to the `VCAP_SERVICES` environment variable. Therefore, no further configuration is needed.
+
 ## License
 
 Licensed under the [Apache License, Version 2.0](LICENSE.txt).

--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ Complete these steps first if you have not already:
 2. Follow the instructions at the above link to connect to Bluemix.
 3. Follow the instructions at the above link to log in to Bluemix.
 
+Create a Cloudant service within Bluemix if it has not already been created:
+
+    $ cf create-service cloudantNoSQLDB Shared cloudant-location-tracker-db
+
 Once you have completed the above steps, simply:
 
     $ cf push

--- a/app.js
+++ b/app.js
@@ -7,6 +7,7 @@ var express = require('express'),
 var app = express();
 
 app.set('port', process.env.PORT || 3000);
+app.set('services', JSON.parse(process.env.VCAP_SERVICES || '{}'));
 
 app.use(express.static(path.join(__dirname, 'public')));
 

--- a/manifest.yml
+++ b/manifest.yml
@@ -3,3 +3,5 @@ applications:
 - name: cloudant-location-tracker
   memory: 64M
   host: cloudant-location-tracker-${random-word}
+  services:
+  - cloudant-location-tracker-db


### PR DESCRIPTION
Added:
- Instructions for creating a Cloudant service within Bluemix
- Binding to Cloudant service within Bluemix
- Procfile to run the project through Foreman
- Parsing of VCAP_SERVICES into a JSON object that is stored as an app setting
- Instructions for configuring local development environment
